### PR TITLE
feat: support history_df for patient history features

### DIFF
--- a/app/routes/training_routes.py
+++ b/app/routes/training_routes.py
@@ -277,7 +277,9 @@ def _run_training_background(job_id: str, temp_file_path: str, original_filename
         # Step 7B: Enrich with feedback from appointment_predictions
         logger.info(f"[Job {job_id}] Enriching dataset with feedback")
         try:
-            feedback_features = load_feedback_as_features(db=db, config_dict=config_dict)
+            feedback_features = load_feedback_as_features(
+                db=db, config_dict=config_dict, history_df=df,
+            )
             if not feedback_features.empty:
                 parquet_rows = len(all_training_data)
                 all_training_data = pd.concat(

--- a/app/services/appointment_feedback_service.py
+++ b/app/services/appointment_feedback_service.py
@@ -31,7 +31,11 @@ _COLUMN_RENAMES = {
 }
 
 
-def load_feedback_as_features(db: Session, config_dict: Dict[str, Any]) -> pd.DataFrame:
+def load_feedback_as_features(
+    db: Session,
+    config_dict: Dict[str, Any],
+    history_df: pd.DataFrame = None,
+) -> pd.DataFrame:
     """
     Query dbo.appointment_predictions for records with a confirmed outcome,
     run feature engineering in-memory, and return the resulting feature DataFrame.
@@ -39,6 +43,8 @@ def load_feedback_as_features(db: Session, config_dict: Dict[str, Any]) -> pd.Da
     Args:
         db:          Active SQLAlchemy session (same DB connection used by the training API).
         config_dict: noshow_lib configuration dict (from blob storage).
+        history_df:  Optional DataFrame with historical appointments to compute
+                     patient history features correctly for feedback records.
 
     Returns:
         DataFrame with engineered features ready to be concatenated with the
@@ -107,7 +113,7 @@ def load_feedback_as_features(db: Session, config_dict: Dict[str, Any]) -> pd.Da
     df = df.rename(columns=_COLUMN_RENAMES)
 
     try:
-        features = engineer_features(df, config_dict)
+        features = engineer_features(df, config_dict, history_df=history_df)
     except Exception as e:
         logger.error(
             f"Feature engineering failed on feedback records: {e}", exc_info=True

--- a/app/services/data_preprocessing.py
+++ b/app/services/data_preprocessing.py
@@ -1,27 +1,33 @@
 import pandas as pd
-from typing import Dict, Any
+from typing import Dict, Any, Optional
 from app.utils.logger import setup_logger
 from noshow_lib.feature_engineering import build_features
 
 logger = setup_logger(__name__)
 
 
-def engineer_features(processed_data: pd.DataFrame, config: Dict[str, Any]) -> pd.DataFrame:
+def engineer_features(
+    processed_data: pd.DataFrame,
+    config: Dict[str, Any],
+    history_df: Optional[pd.DataFrame] = None,
+) -> pd.DataFrame:
     """
     Engineer features using noshow_lib's build_features.
     This replaces the old process of load_and_process_data + build_features separately.
-    
+
     Args:
         processed_data: Raw input dataframe
         config: Configuration dictionary from config.yaml
-        
+        history_df: Optional DataFrame with historical appointments (including Status/outcome).
+                    Used to compute patient history features correctly during inference.
+
     Returns:
         DataFrame with engineered features ready for training
     """
     logger.info("Engineering features using noshow_lib.build_features")
-    
-    features = build_features(processed_data, config)
+
+    features = build_features(processed_data, config, history_df=history_df)
     logger.info(f"Feature engineering complete. Shape: {features.shape}")
-    
+
     return features
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,6 @@ pytest
 pytest-asyncio
 httpx
 pyyaml
-git+https://github.com/tcc-no-show-appointment/noshow_lib.git@v0.3.2
+git+https://github.com/tcc-no-show-appointment/noshow_lib.git@v0.3.3
 sqlalchemy
 pyodbc


### PR DESCRIPTION
## Summary
- Adiciona parâmetro opcional `history_df` em `engineer_features()` e `load_feedback_as_features()`
- Passa dados do upload como histórico ao processar registros de feedback do banco
- Atualiza noshow_lib para v0.3.3 (com suporte a `history_df` em `build_features()` e `predict()`)

## Arquivos alterados
- `app/services/data_preprocessing.py` — pass-through do `history_df`
- `app/services/appointment_feedback_service.py` — aceita e passa `history_df`
- `app/routes/training_routes.py` — passa `df` como histórico ao feedback service
- `requirements.txt` — bump noshow_lib v0.3.2 → v0.3.3

## Test plan
- [ ] Verificar que o pipeline de treino continua funcionando sem alterações no fluxo principal
- [ ] Verificar que feedback records recebem histórico do upload para features de paciente
- [ ] Verificar retrocompatibilidade (chamadas sem history_df continuam funcionando)